### PR TITLE
[Fix] Search results styling

### DIFF
--- a/front/src/app/views/home/home.component.html
+++ b/front/src/app/views/home/home.component.html
@@ -4,52 +4,48 @@
     <a [routerLink]="['auth']" [state]="{ isSignUp: true }">Sign Up</a>
   </nav>
   <div class="main" [ngClass]="{ 'fix-top': searchQuery !== '' }">
-    <img class="logo" src="../../assets/SMAT_LOGO.svg" alt="SMAT logo" />
+    <header>
+      <img class="logo" src="../../assets/SMAT_LOGO.svg" alt="SMAT logo" />
+    </header>
 
-    <div class="search-container-template">
-      <div class="search-container">
-        <div class="input-container">
-          <svg
-            class="search-svg"
-            width="29"
-            height="28"
-            viewBox="0 0 29 28"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M20.5 10.5C20.5 15.4056 16.3132 19.5 11 19.5C5.68677 19.5 1.5 15.4056 1.5 10.5C1.5 5.59443 5.68677 1.5 11 1.5C16.3132 1.5 20.5 5.59443 20.5 10.5Z"
-              stroke="grey"
-              stroke-width="3"
-            />
-            <line
-              x1="18.0607"
-              y1="17.9393"
-              x2="27.0607"
-              y2="26.9393"
-              stroke="grey"
-              stroke-width="3"
-            />
-          </svg>
-          <input
-            autocomplete="off"
-            class="search-bar"
-            id="search"
-            name="search"
-            type="text"
-            placeholder="Search"
-            [(ngModel)]="searchQuery"
-            (ngModelChange)="getMatchedPosts()"
+    <div class="search-container">
+      <div class="input-container">
+        <svg
+          class="search-svg"
+          width="29"
+          height="28"
+          viewBox="0 0 29 28"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20.5 10.5C20.5 15.4056 16.3132 19.5 11 19.5C5.68677 19.5 1.5 15.4056 1.5 10.5C1.5 5.59443 5.68677 1.5 11 1.5C16.3132 1.5 20.5 5.59443 20.5 10.5Z"
+            stroke="grey"
+            stroke-width="3"
           />
-        </div>
-        <div class="search-results">
-          <div style="width: 100%" *ngFor="let post of matchedPosts">
-            <app-matched-post [post]="post"></app-matched-post>
-          </div>
-        </div>
+          <line
+            x1="18.0607"
+            y1="17.9393"
+            x2="27.0607"
+            y2="26.9393"
+            stroke="grey"
+            stroke-width="3"
+          />
+        </svg>
+        <input
+          autocomplete="off"
+          class="search-bar"
+          id="search"
+          name="search"
+          type="text"
+          placeholder="Search"
+          [(ngModel)]="searchQuery"
+          (ngModelChange)="getMatchedPosts()"
+        />
+      </div>
+      <div class="search-results">
+        <app-matched-post *ngFor="let post of matchedPosts" [post]="post"></app-matched-post>
       </div>
     </div>
-
-    <a class="search-button">Search</a>
   </div>
 </div>

--- a/front/src/app/views/home/home.component.scss
+++ b/front/src/app/views/home/home.component.scss
@@ -8,7 +8,6 @@
 }
 
 .nav-bar {
-  // max-width: 2000px;
   margin: 0 auto;
   display: flex;
   justify-content: flex-end;
@@ -19,27 +18,30 @@
 .nav-bar a {
   text-decoration: none;
   color: $text-color;
+
+  &:hover,
+  &:focus {
+    opacity: 0.9;
+  }
 }
 
-.nav-bar a:hover,
-.nav-bar a:focus {
-  opacity: 0.9;
-}
 
 .main {
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-
   width: 90%;
   margin: 0 auto;
   margin-top: 1.2em;
-}
 
-.logo {
-  width: 70%;
-  max-width: calc(0.7 * 0.9 * 600px);
+  header {
+    width: 400px;
+
+    .logo {
+      width: 100%;
+    }
+  }
 }
 
 .input-container {
@@ -52,17 +54,7 @@
   width: 0.8em;
 }
 
-.search-container-template {
-  position: relative;
-  margin-top: 1.5em;
-  width: 100%;
-  height: 2em;
-  max-width: 750px;
-}
-
 .search-container {
-  position: absolute;
-  top: -1.5em;
   margin-top: 1.5em;
   width: 100%;
   max-width: 750px;
@@ -75,26 +67,25 @@
   border-width: 3px;
 
   box-shadow: 0 6px 6px rgba(0, 0, 0, 0.2);
+
+  &:hover,
+  &:focus {
+    box-shadow: 0 10px 10px rgba(0, 0, 0, 0.2);
+  }
 }
 
-.search-container:hover,
-.search-container:focus {
-  box-shadow: 0 10px 10px rgba(0, 0, 0, 0.2);
-}
 
 .search-results {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-
   max-height: 620px;
   overflow: auto;
   width: 100%;
-}
 
-.search-results:empty {
-  border-top: none;
+  &:empty {
+    border-top: none;
+  }
 }
 
 .search-bar {
@@ -130,7 +121,6 @@
   .main {
     // margin-top: 0;
     justify-content: center;
-    height: 80vh;
     // max-height: 2000px;
   }
 


### PR DESCRIPTION
This PR fixes the results list being cut-off, basically due to
the `justify-content: center` which is not really necessary since
no vertical alignment is needed in a top-to-bottom list.

This also removes the `search-template-container` div which is also
not necessary as all styles can be handled from the other `search-container`
wrapper.